### PR TITLE
Upgrade VEP to v90

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,11 @@
-FROM ubuntu:xenial
+FROM ensemblorg/ensembl-vep:release_90.10
 MAINTAINER Susanna Kiwala <ssiebert@wustl.edu>
 
 LABEL \
-  version="87" \
-  description="VEP image for use in Workflows"
+  version="90" \
+  description="VEP image with Wildtype and Downstream plugins"
 
-RUN apt-get update && \
-    apt-get install -y \
-        git \
-        bioperl
-
-RUN mkdir /opt/vep/
-
-WORKDIR /opt/vep
-RUN git clone https://github.com/Ensembl/ensembl-vep.git --branch release/87 --single-branch
-
-WORKDIR /opt/vep/ensembl-vep
-RUN perl INSTALL.pl --NO_HTSLIB
-
-WORKDIR /
-RUN ln -s /opt/vep/ensembl-vep/scripts/variant_effect_predictor/vep.pl /usr/bin/vep.pl
-
-ENTRYPOINT ["/usr/bin/perl", "/usr/bin/vep.pl"]
+RUN mkdir -p /home/vep/Plugins
+WORKDIR /home/vep/Plugins
+RUN wget https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/90/Downstream.pm
+RUN wget https://raw.githubusercontent.com/griffithlab/pVACtools/master/tools/pvacseq/VEP_plugins/Wildtype.pm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:xenial
+MAINTAINER Susanna Kiwala <ssiebert@wustl.edu>
+
+LABEL \
+  version="86" \
+  description="VEP image for use in Workflows"
+
+RUN apt-get update && \
+    apt-get install -y \
+        bioperl \
+        wget \
+        unzip \
+        libfile-copy-recursive-perl \
+        libarchive-extract-perl \
+        libarchive-zip-perl \
+        libapache-dbi-perl \
+        curl
+
+RUN mkdir /opt/vep/
+
+WORKDIR /opt/vep
+RUN wget https://github.com/Ensembl/ensembl-tools/archive/release/86.zip && \
+    unzip 86.zip
+
+WORKDIR /opt/vep/ensembl-tools-release-86/scripts/variant_effect_predictor/
+RUN perl INSTALL.pl --NO_HTSLIB
+
+WORKDIR /
+RUN ln -s /opt/vep/ensembl-tools-release-86/scripts/variant_effect_predictor/variant_effect_predictor.pl /usr/bin/variant_effect_predictor.pl
+
+ENTRYPOINT ["perl /usr/bin/variant_effect_predictor.pl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN perl INSTALL.pl --NO_HTSLIB
 WORKDIR /
 RUN ln -s /opt/vep/ensembl-tools-release-86/scripts/variant_effect_predictor/variant_effect_predictor.pl /usr/bin/variant_effect_predictor.pl
 
-ENTRYPOINT ["perl", "/usr/bin/variant_effect_predictor.pl"]
+ENTRYPOINT ["/usr/bin/perl", "/usr/bin/variant_effect_predictor.pl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN perl INSTALL.pl --NO_HTSLIB
 WORKDIR /
 RUN ln -s /opt/vep/ensembl-tools-release-86/scripts/variant_effect_predictor/variant_effect_predictor.pl /usr/bin/variant_effect_predictor.pl
 
-ENTRYPOINT ["perl /usr/bin/variant_effect_predictor.pl"]
+ENTRYPOINT ["perl", "/usr/bin/variant_effect_predictor.pl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,30 +2,23 @@ FROM ubuntu:xenial
 MAINTAINER Susanna Kiwala <ssiebert@wustl.edu>
 
 LABEL \
-  version="86" \
+  version="87" \
   description="VEP image for use in Workflows"
 
 RUN apt-get update && \
     apt-get install -y \
-        bioperl \
-        wget \
-        unzip \
-        libfile-copy-recursive-perl \
-        libarchive-extract-perl \
-        libarchive-zip-perl \
-        libapache-dbi-perl \
-        curl
+        git \
+        bioperl
 
 RUN mkdir /opt/vep/
 
 WORKDIR /opt/vep
-RUN wget https://github.com/Ensembl/ensembl-tools/archive/release/86.zip && \
-    unzip 86.zip
+RUN git clone https://github.com/Ensembl/ensembl-vep.git --branch release/87 --single-branch
 
-WORKDIR /opt/vep/ensembl-tools-release-86/scripts/variant_effect_predictor/
+WORKDIR /opt/vep/ensembl-vep
 RUN perl INSTALL.pl --NO_HTSLIB
 
 WORKDIR /
-RUN ln -s /opt/vep/ensembl-tools-release-86/scripts/variant_effect_predictor/variant_effect_predictor.pl /usr/bin/variant_effect_predictor.pl
+RUN ln -s /opt/vep/ensembl-vep/scripts/variant_effect_predictor/vep.pl /usr/bin/vep.pl
 
-ENTRYPOINT ["/usr/bin/perl", "/usr/bin/variant_effect_predictor.pl"]
+ENTRYPOINT ["/usr/bin/perl", "/usr/bin/vep.pl"]


### PR DESCRIPTION
VEP now offers its own docker container. The v90 container is based on the ensembl version and just adds the Wildtype and Downstream plugins to it.